### PR TITLE
fix(oci): copy custom /etc/passwd file

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -16,3 +16,8 @@ License: Apache-2.0
 Files: anki-sync-server/imgs/ah-logo.png
 Copyright: Alex Fraser https://apps.ankiweb.net/
 License: LicenseRef-anki-logo
+
+# this file contains the user used in the container (see https://github.com/federdaemn/docker-anki-sync-server/issues/2)
+Files: tools/minimal-passwd.txt
+Copyright: 2023 Frederik Zorn <federdaemn@mail.de>
+License: Apache-2.0

--- a/SETUP.md
+++ b/SETUP.md
@@ -14,8 +14,8 @@ version: "3.7"
 services:
 
   anki-sync-server:
-    # https://github.com/federdaemn/anki-sync-server/blob/main/SETUP.md
-    image: ghcr.io/federdaemn/anki-sync-server:2.1.66
+    # https://github.com/federdaemn/docker-anki-sync-server/blob/main/SETUP.md
+    image: ghcr.io/federdaemn/anki-sync-server:23.10.1
     container_name: anki-sync-server
     restart: unless-stopped
     # these are sample passwords, please change them

--- a/anki-sync-server/containerfile
+++ b/anki-sync-server/containerfile
@@ -55,6 +55,9 @@ RUN \
 # copy binary container with nothing other to reduce container size
 FROM scratch
 
+# copy /etc/passwd because docker cannot create one in a scratch container
+COPY tools/minimal-passwd.txt /etc/passwd
+
 # copy binary from builder
 COPY --from=builder /output/anki-sync-server /app/anki-sync-server
 
@@ -65,7 +68,7 @@ ENV \
   SYNC_PORT="27701"
 
 # switch user for better security
-USER anki-sync-server
+USER scratch-user
 
 # don't forget to set at least SYNC_USER1
 CMD [ "/app/anki-sync-server" ]

--- a/tools/convert-arch-cargo.sh
+++ b/tools/convert-arch-cargo.sh
@@ -21,7 +21,7 @@ case $TARGET in
 
   "amd64")
 	  echo "x86_64-unknown-linux-gnu" > /.cargo-platform.txt
-    echo "NOTHING=unimportant" > /.cargo-linker.txt
+    echo "NOTHING=nothing" > /.cargo-linker.txt
     echo "gcc g++" > /.c-compiler.txt
 	;;
   "arm64") 

--- a/tools/minimal-passwd.txt
+++ b/tools/minimal-passwd.txt
@@ -1,0 +1,1 @@
+scratch-user:*:65534:65534:scratch-user:/nonexistent:/sbin/nologin


### PR DESCRIPTION
* copy from host
* new username: scratch-user
* includes scratch-user because docker cannot create users in scratch
* source: https://stackoverflow.com/a/67703976 a. https://medium.com/@lizrice/non-privileged-containers-based-on-the-scratch-image-a80105d6d341

fixes https://github.com/federdaemn/docker-anki-sync-server/issues/2